### PR TITLE
update buildout after recent merges and using 7.0 branches

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -12,20 +12,15 @@ versions = versions
 [odoo]
 recipe = anybox.recipe.openerp:server
 
-version = git https://github.com/OCA/OCB.git odoo d6e7cd50ce3db093dfd011723e766d6a3096e239 branch=7.0
+version = git https://github.com/OCA/OCB.git odoo 7.0
 
-addons = git https://github.com/OCA/l10n-italy.git parts/l10n-italy  65c97a86aa6c550a1b3b6092a4a4cab647e96bce branch=7.0
-         git https://github.com/OCA/server-tools.git parts/server-tools 774a87c38d409d98838a1dca7dd27e66f49ee031 branch=7.0
-         git https://github.com/OCA/partner-contact.git parts/partner-contact 8a3205c7eff970fcf72bf673b09cf57fbac27fc0 branch=7.0
-         git https://github.com/OCA/account-invoicing.git parts/account-invoicing fff1fe2bc680f9dec933e607ba67352d1e96251b branch=7.0
-         git https://github.com/OCA/stock-logistics-workflow.git parts/stock-logistics-workflow edfc32921ece635ed37ffe69148484f1fe905433 branch=7.0
-         git https://github.com/OCA/account-payment.git parts/account-payment 7066639857f432c884981b11b06e42a49e9cf0e0 branch=7.0
+addons = git https://github.com/OCA/l10n-italy.git parts/l10n-italy  7.0
+         git https://github.com/OCA/server-tools.git parts/server-tools 7.0
+         git https://github.com/OCA/partner-contact.git parts/partner-contact 7.0
+         git https://github.com/OCA/account-invoicing.git parts/account-invoicing 7.0
+         git https://github.com/OCA/stock-logistics-workflow.git parts/stock-logistics-workflow 7.0
+         git https://github.com/OCA/account-payment.git parts/account-payment 7.0
          local src
-
-merges = git origin parts/l10n-italy pull/117/head ; l10n_it_pec_messages
-         git origin parts/server-tools pull/140/head ; fetchmail_bydate
-         git origin parts/l10n-italy pull/97/head ; l10n_it_fatturapa*
-         git origin parts/l10n-italy pull/119/head ; l10n_it_fatturapa notifications
 
 clean = true
 


### PR DESCRIPTION
Dato che le 4 PR in 'merges' sono state mergiate, le rimuovo da merges e aggiorno la versione dei branch ufficiali.
Inoltre propongo di usare, nel buildout pubblico, l'ultima versione dei branch (con 7.0 invece dello SHA), lasciando poi alle specifiche installazioni la decisione se fissare o meno le revisioni
@archetipo @angedras 